### PR TITLE
Implement layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ If you're switching from any other special remote that works with Google Drive (
 
 ## Repository layouts
 The following layouts are currently supported:
-* nested - A tree structure with a maximum width of 500 000 nodes is used. This is the only layout that will never run full (by adding a new level every 499999*500000 keys).
-* lower - A two-level lower case directory hierarchy is used (using git-annex's DIRHASH-LOWER MD5-based format). This choice requires git-annex 6.20160511 or later. Runs full at 500000*16^6 keys.
-* mixed - A two-level mixed case directory hierarchy is used (using git-annex's DIRHASH format). Runs full at 500000*32^4 keys.
-* nodir - (deprecated) No directory hierarchy is used. This used to be the default layout for Google Drive until Google introduced the file limit. Runs full at 500000 keys and thus should be avoided.
+* `nested` - A tree structure with a maximum width of 500 000 nodes is used. This is the only layout that will never run full (by adding a new level every 499999*500000 keys).
+* `lower` - A two-level lower case directory hierarchy is used (using git-annex's DIRHASH-LOWER MD5-based format). This choice requires git-annex 6.20160511 or later. Runs full at 500000*16^6 keys.
+* `mixed` - A two-level mixed case directory hierarchy is used (using git-annex's DIRHASH format). Runs full at 500000*32^4 keys.
+* `nodir` - (deprecated) No directory hierarchy is used. This used to be the default layout for Google Drive until Google introduced the file limit. Runs full at 500000 keys and thus should be avoided.
 
 You can switch layouts at any time using `git annex enableremote <remote_name> layout=<new_layout>`. git-annex-remote-googledrive will then start to store new keys in the new
 layout. It will always find existing keys, no matter in which layout they are stored. Existing keys will be

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ If you're switching from any other special remote that works with Google Drive (
 
 ## Repository layouts
 The following layouts are currently supported:
-* `nested` - A tree structure with a maximum width of 500 000 nodes is used. This is the only layout that will never run full (by adding a new level every 499999*500000 keys).
+* `nested` - A tree structure with a maximum width of 500 000 nodes is used. This is the only layout that will never run full (by adding a new level every 499999*500000 keys). Will be the default layout starting with v2.0.0.
 * `lower` - A two-level lower case directory hierarchy is used (using git-annex's DIRHASH-LOWER MD5-based format). This choice requires git-annex 6.20160511 or later. Runs full at 500000*16^6 keys.
 * `mixed` - A two-level mixed case directory hierarchy is used (using git-annex's DIRHASH format). Runs full at 500000*32^4 keys.
-* `nodir` - (deprecated) No directory hierarchy is used. This used to be the default layout for Google Drive until Google introduced the file limit. Runs full at 500000 keys and thus should be avoided.
+* `nodir` - (deprecated) No directory hierarchy is used. This used to be the most efficient layout for Google Drive until Google introduced the file limit. Runs full at 500000 keys and thus should be avoided. Will stay the default layout for compatibility until v2.0.0.
 
 You can switch layouts at any time using `git annex enableremote <remote_name> layout=<new_layout>`. git-annex-remote-googledrive will then start to store new keys in the new
 layout. It will always find existing keys, no matter in which layout they are stored. Existing keys will be

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -22,7 +22,7 @@ from . import _default_client_id as DEFAULT_CLIENT_ID
 from drivelib import GoogleDrive
 from drivelib import Credentials
 
-from .keys import Key, NodirRemoteRoot
+from .keys import Key, NodirRemoteRoot, NestedRemoteRoot
 from .keys import ExportRemoteRoot, ExportKey
 from .keys import HasSubdirError, NotAFileError, NotAuthenticatedError
 
@@ -112,7 +112,7 @@ class GoogleRemote(annexremote.ExportRemote):
             if exporttree:
                 root_class = ExportRemoteRoot
             else:
-                root_class = NodirRemoteRoot
+                root_class = NestedRemoteRoot
 
             if self.credentials is None:
                 raise RemoteError("Stored credentials are invalid. Please re-run `git-annex-remote-googledrive setup` and `git annex enableremote <remotename>`")

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -24,7 +24,6 @@ from drivelib import Credentials
 
 from .keys import RemoteRoot, Key
 from .keys import ExportRemoteRoot, ExportKey
-from .keys import MigrationRoot
 from .keys import HasSubdirError, NotAFileError, NotAuthenticatedError
 
 
@@ -130,13 +129,6 @@ class GoogleRemote(annexremote.ExportRemote):
                         "Set to 'true' if you don't want to see the warning.",
             'token':    "Token file that was created by `git-annex-remote-googledrive setup`",
         }
-
-    def migrate(self, prefix):
-        with open("token.json", 'r') as fp:
-            creds = fp.read()
-
-        root = self._get_root(MigrationRoot, creds, prefix)
-        return root.migrate()
 
     def _get_root(self, RootClass, creds, prefix=None, root_id=None):
         #TODO: Maybe implement as property, too
@@ -260,7 +252,7 @@ class GoogleRemote(annexremote.ExportRemote):
             try:
                 self.root = self._get_root(RemoteRoot, credentials, prefix, root_id)
             except HasSubdirError:
-                raise RemoteError("Specified folder has subdirectories. Are you sure 'prefix' or 'id' is set correctly? In case you're migrating from gdrive or rclone, run 'git-annex-remote-googledrive migrate {prefix}' first.".format(prefix=prefix))
+                raise RemoteError("Specified folder has subdirectories. Are you sure 'prefix' or 'id' is set correctly? As of now, git-annex-remote-googledrive only supports the 'nodir' layout.")
         
         self.annex.setconfig('root_id', self.root.id)
         self.credentials = self.root.creds()

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -266,7 +266,7 @@ class GoogleRemote(annexremote.ExportRemote):
         else:
             upload_path = fpath
 
-        self.root.key(key).upload(
+        self.root.new_key(key).upload(
                         str(upload_path), 
                         chunksize=self.chunksize,
                         progress_handler=self.annex.progress)

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -119,9 +119,9 @@ class GoogleRemote(annexremote.ExportRemote):
 
             try:
                 if prefix:
-                    root = root_class.from_path(self.credentials, prefix, uuid=self.uuid, local_appdir=self.local_appdir)
+                    root = root_class.from_path(self.credentials, prefix, annex=self.annex, uuid=self.uuid, local_appdir=self.local_appdir)
                 else:
-                    root = root_class.from_id(self.credentials, root_id, uuid=self.uuid, local_appdir=self.local_appdir)
+                    root = root_class.from_id(self.credentials, root_id, annex=self.annex, uuid=self.uuid, local_appdir=self.local_appdir)
             except JSONDecodeError:
                 raise RemoteError("Access token invalid, please re-run `git-annex-remote-googledrive setup`")
             except (NotAuthenticatedError, RefreshError):

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -110,7 +110,7 @@ class GoogleRemote(annexremote.ExportRemote):
 
     @property
     def root(self):
-        if not hasattr(self, '_root') or self._root is None:
+        if not hasattr(self, '_root') or self._root is None: # pylint: disable=access-member-before-definition
             prefix = self.annex.getconfig('prefix')
             root_id = self.annex.getconfig('root_id')
             exporttree = self.annex.getconfig('exporttree')

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -104,6 +104,8 @@ class GoogleRemote(annexremote.ExportRemote):
             'mute-api-lockdown-warning':
                         "Set to 'true' if you don't want to see the warning.",
             'token':    "Token file that was created by `git-annex-remote-googledrive setup`",
+            'auto_fix_full':    "`yes` if the remote should try to fix full-folder issues"
+                                " automatically. See https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder",
         }
 
     @property

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -145,8 +145,6 @@ class GoogleRemote(annexremote.ExportRemote):
                     raise RemoteError("Prefix {} does not exist or does not point to a folder.".format(prefix))
                 else:
                     raise RemoteError("File ID {} does not exist or does not point to a folder.".format(root_id))
-            except HasSubdirError:
-                raise RemoteError("Specified folder has subdirectories. Are you sure 'prefix' or 'id' is set correctly? As of now, git-annex-remote-googledrive only supports the 'nodir' layout.")
 
             if root.id != root_id and not (hasattr(self, 'isinitremote') and self.isinitremote is True):
                 raise RemoteError("ID of root folder changed. Was the repo moved? Please check remote and re-run git annex enableremote")
@@ -178,15 +176,14 @@ class GoogleRemote(annexremote.ExportRemote):
     def layout(self):
         gdrive_layout = self.annex.getconfig("gdrive_layout")
         rclone_layout = self.annex.getconfig("rclone_layout")
-        default_layout = "nested"
+        default_layout = "nodir"
+        self.annex.info("No layout was specified. Defaulting to `nodir` for compatibility. This will change in v2.0.0.")
 
         # delete rclone_layout but import it beforehand if gdrive_layout wasn't set
         if rclone_layout:
-            if gdrive_layout:
-                self.annex.setconfig("rclone_layout", "")
-            else:
+            if not gdrive_layout:
                 self.annex.setconfig("gdrive_layout", rclone_layout)
-                self.annex.setconfig("rclone_layout", "")
+            self.annex.setconfig("rclone_layout", "")
         
         return gdrive_layout or rclone_layout or default_layout
 

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -82,6 +82,8 @@ class GoogleRemote(annexremote.ExportRemote):
         self.configs = {
             'prefix': "The path to the folder that will be used for the remote."
                         " If it doesn't exist, it will be created.",
+            'gdrive_layout': "How the keys should be stored in the remote folder."
+                             "Available options: `nested`(default) and `nodir`.",
             'root_id': "Instead of the path, you can specify the ID of a folder."
                         " The folder must already exist. This will make it independent"
                         " from the path and it will always be found by git-annex, no matter"
@@ -113,7 +115,13 @@ class GoogleRemote(annexremote.ExportRemote):
             if exporttree == "yes":
                 root_class = ExportRemoteRoot
             else:
-                root_class = NestedRemoteRoot
+                layout_mapping = {
+                    'nodir':    NodirRemoteRoot,
+                    'nested':   NestedRemoteRoot,
+                }
+                root_class = layout_mapping.get(self.layout, None)
+                if root_class is None:
+                    raise RemoteError("`gdrive_layout` must be one of {}".format(list(layout_mapping.keys())))
 
             if self.credentials is None:
                 raise RemoteError("Stored credentials are invalid. Please re-run `git-annex-remote-googledrive setup` and `git annex enableremote <remotename>`")
@@ -162,6 +170,22 @@ class GoogleRemote(annexremote.ExportRemote):
         return self._local_appdir
 
     @property
+    def layout(self):
+        gdrive_layout = self.annex.getconfig("gdrive_layout")
+        rclone_layout = self.annex.getconfig("rclone_layout")
+        default_layout = "nested"
+
+        # delete rclone_layout but import it beforehand if gdrive_layout wasn't set
+        if rclone_layout:
+            if gdrive_layout:
+                self.annex.setconfig("rclone_layout", "")
+            else:
+                self.annex.setconfig("gdrive_layout", rclone_layout)
+                self.annex.setconfig("rclone_layout", "")
+        
+        return gdrive_layout or rclone_layout or default_layout
+
+    @property
     def info(self):
         return_dict = {}
         prefix = self.annex.getconfig("prefix")
@@ -169,6 +193,7 @@ class GoogleRemote(annexremote.ExportRemote):
             return_dict['remote prefix'] = prefix
         else:
             return_dict['remote root-id'] = self.annex.getconfig("root_id")
+        return_dict['remote layout'] = self.layout
         return_dict['transfer chunk size'] = humanfriendly.format_size(self.chunksize, binary=True)
         return return_dict
 

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -22,7 +22,7 @@ from . import _default_client_id as DEFAULT_CLIENT_ID
 from drivelib import GoogleDrive
 from drivelib import Credentials
 
-from .keys import RemoteRoot, Key
+from .keys import Key, NodirRemoteRoot
 from .keys import ExportRemoteRoot, ExportKey
 from .keys import HasSubdirError, NotAFileError, NotAuthenticatedError
 
@@ -112,7 +112,7 @@ class GoogleRemote(annexremote.ExportRemote):
             if exporttree:
                 root_class = ExportRemoteRoot
             else:
-                root_class = RemoteRoot
+                root_class = NodirRemoteRoot
 
             if self.credentials is None:
                 raise RemoteError("Stored credentials are invalid. Please re-run `git-annex-remote-googledrive setup` and `git annex enableremote <remotename>`")
@@ -131,8 +131,6 @@ class GoogleRemote(annexremote.ExportRemote):
                     raise RemoteError("Prefix {} does not exist or does not point to a folder.".format(prefix))
                 else:
                     raise RemoteError("File ID {} does not exist or does not point to a folder.".format(root_id))
-            except Exception as e:
-                raise RemoteError("Failed to connect with Google. Please check your internet connection.", e)
             except HasSubdirError:
                 raise RemoteError("Specified folder has subdirectories. Are you sure 'prefix' or 'id' is set correctly? As of now, git-annex-remote-googledrive only supports the 'nodir' layout.")
 

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -23,7 +23,7 @@ from drivelib import GoogleDrive
 from drivelib import Credentials
 from drivelib.errors import NumberOfChildrenExceededError
 
-from .keys import Key, NodirRemoteRoot, NestedRemoteRoot
+from .keys import Key, NodirRemoteRoot, NestedRemoteRoot, LowerRemoteRoot, DirectoryRemoteRoot, MixedRemoteRoot
 from .keys import ExportRemoteRoot, ExportKey
 from .keys import HasSubdirError, NotAFileError, NotAuthenticatedError
 
@@ -83,7 +83,7 @@ class GoogleRemote(annexremote.ExportRemote):
             'prefix': "The path to the folder that will be used for the remote."
                         " If it doesn't exist, it will be created.",
             'gdrive_layout': "How the keys should be stored in the remote folder."
-                             "Available options: `nested`(default) and `nodir`.",
+                             "Available options: `nested`(default), `nodir`, `lower` and `mixed`.",
             'root_id': "Instead of the path, you can specify the ID of a folder."
                         " The folder must already exist. This will make it independent"
                         " from the path and it will always be found by git-annex, no matter"
@@ -120,6 +120,9 @@ class GoogleRemote(annexremote.ExportRemote):
                 layout_mapping = {
                     'nodir':    NodirRemoteRoot,
                     'nested':   NestedRemoteRoot,
+                    'lower':    LowerRemoteRoot,
+                    #'directory': DirectoryRemoteRoot,
+                    'mixed':    MixedRemoteRoot,
                 }
                 root_class = layout_mapping.get(self.layout, None)
                 if root_class is None:

--- a/git_annex_remote_googledrive/google_remote.py
+++ b/git_annex_remote_googledrive/google_remote.py
@@ -110,7 +110,7 @@ class GoogleRemote(annexremote.ExportRemote):
             prefix = self.annex.getconfig('prefix')
             root_id = self.annex.getconfig('root_id')
             exporttree = self.annex.getconfig('exporttree')
-            if exporttree:
+            if exporttree == "yes":
                 root_class = ExportRemoteRoot
             else:
                 root_class = NestedRemoteRoot

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -111,17 +111,31 @@ class RemoteRoot(RemoteRootBase):
         except FileNotFoundError:
             pass
     
-    @abc.abstractmethod
-    def _lookup_remote_file(self, key: str):
-        raise NotImplementedError
+    def _lookup_remote_file(self, key: str) -> DriveFile:
+        remote_file = self._find_elsewhere(key)
+        parent = self._lookup_parent(key)
+        if remote_file.parent != parent:
+            self._migrate_remote_file(remote_file, parent)
+        return remote_file
+
+    def _migrate_remote_file(self, remote_file: DriveFile, new_parent: DriveFolder):
+        original_parent = remote_file.parent
+        remote_file.move(new_parent)
+        self._trash_empty_parents(original_parent)
 
     @abc.abstractmethod
-    def _new_remote_file(self, key: str):
+    def _lookup_parent(self, key: str) -> DriveFolder:
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def handle_full_folder(self):
-        raise NotImplementedError
+    def _new_remote_file(self, key: str) -> DriveFile:
+        return self._lookup_parent(key).new_file(key)
+
+    def handle_full_folder(self, key: str = None):
+        full_folder = self._lookup_parent(key).resolve()
+        error_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
+                            " Please switch to a different layout and consult"\
+                            " https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder.".format(full_folder)
+        raise RemoteError(error_message)
 
     def _is_descendant_of_root(self, f: DriveFile) -> bool:
         path = ""
@@ -205,24 +219,10 @@ class NodirRemoteRoot(RemoteRoot):
                         " Thus, `nodir` layout is no longer a good choice. Please consider migrating"
                         " to a different layout.")
 
-    def _lookup_remote_file(self, key: str) -> DriveFile:
-        try: 
-            remote_file = self.folder.child(key)
-        except FileNotFoundError:
-            if self.has_subdirs:
-                self.annex.debug("Not found. Trying different locations.")
-                remote_file = self._find_elsewhere(key)
-                original_parent = remote_file.parent
-                remote_file.move(self.folder)
-                self._trash_empty_parents(original_parent)
-            else:
-                raise
-        return remote_file
+    def _lookup_parent(self, key):
+        return self.folder
 
-    def _new_remote_file(self, key):
-        return self.folder.new_file(key)
-
-    def handle_full_folder(self):
+    def handle_full_folder(self, key=None):
         error_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
                             " Please switch to a different layout and consult"\
                             " https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder.".format(self.folder.name)
@@ -277,16 +277,13 @@ class NestedRemoteRoot(RemoteRoot):
 
         yield from self._sub_generator(parent_folder=reserved_subfolder)
 
-    def _lookup_remote_file(self, key):
-        return self._find_elsewhere(key)
-
     def _auto_fix_full(self):
         super()._auto_fix_full()
         del self._subfolders
         self.current_folder = self.next_subfolder()
 
 
-    def _new_remote_file(self, key):
+    def _new_remote_file(self, key) -> DriveFile:
         if self.current_folder is None:
             if self.annex.getconfig("auto_fix_full") == "yes":
                 if self.creator != "from_id":
@@ -305,7 +302,7 @@ class NestedRemoteRoot(RemoteRoot):
                                 )
         return self.current_folder.new_file(key)
 
-    def handle_full_folder(self):
+    def handle_full_folder(self, key=None):
         self.current_folder.rename(self.current_folder.name+self.full_suffix)
         self.current_folder = self.next_subfolder()
 

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -228,6 +228,28 @@ class NodirRemoteRoot(RemoteRoot):
                             " https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder.".format(self.folder.name)
         raise RemoteError(error_message)
 
+class LowerRemoteRoot(RemoteRoot):
+    def _lookup_parent(self, key: str) -> DriveFolder:
+        path = self.annex.dirhash_lower(key)
+        return self.folder.create_path(path)
+
+    def _migrate_remote_file(self, remote_file: DriveFile, new_parent: DriveFolder):
+        original_parent = remote_file.parent
+        # file will be replacing its own parent if migrating from directory layout
+        remote_file.move(new_parent, ignore_existing=(remote_file.name == remote_file.parent.name)) 
+        self._trash_empty_parents(original_parent)
+
+class DirectoryRemoteRoot(RemoteRoot):
+    def _lookup_parent(self, key: str) -> DriveFolder:
+        path = '/'.join((self.annex.dirhash_lower(key), key))
+        # FIXME: fails if migrating from lower layout
+        return self.folder.create_path(path)
+        
+class MixedRemoteRoot(RemoteRoot):
+    def _lookup_parent(self, key: str) -> DriveFolder:
+        path = self.annex.dirhash(key)
+        return self.folder.create_path(path)
+
 class NestedRemoteRoot(RemoteRoot):
     def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
         super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -217,7 +217,7 @@ class NodirRemoteRoot(RemoteRoot):
             self.has_subdirs = False
         self.annex.info("WARNING: Google has introduced a maximum file count per folder."
                         " Thus, `nodir` layout is no longer a good choice. Please consider migrating"
-                        " to a different layout.")
+                        " to a different layout. See https://github.com/Lykos153/git-annex-remote-googledrive#repository-layouts")
 
     def _lookup_parent(self, key):
         return self.folder

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -198,9 +198,8 @@ class NodirRemoteRoot(RemoteRoot):
         else:
             self.has_subdirs = False
         self.annex.info("WARNING: Google has introduced a maximum file count per folder."
-                        " Thus, `nodir` is no longer a good choice. Please consider migrating"
+                        " Thus, `nodir` layout is no longer a good choice. Please consider migrating"
                         " to a different layout.")
-        # automatically migrate to nested if nodir wasn't explicitely asked for
 
     def _lookup_remote_file(self, key: str) -> DriveFile:
         try: 
@@ -221,8 +220,8 @@ class NodirRemoteRoot(RemoteRoot):
 
     def handle_full_folder(self):
         error_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
-                            " Please switch to a different layout and drop at least one key "\
-                            " from the remote so it can automatically migrate.".format(self.folder.name)
+                            " Please switch to a different layout and consult"\
+                            " https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder.".format(self.folder.name)
         raise RemoteError(error_message)
 
 class NestedRemoteRoot(RemoteRoot):

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -227,9 +227,6 @@ class NodirRemoteRoot(RemoteRoot):
 class NestedRemoteRoot(RemoteRoot):
     def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
         super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)
-        self.full_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
-                            " Please drop at least one key from the remote, so it can automatically" \
-                            " migrate to the 'nested' layout.".format(self.folder.name)
         self.nested_prefix = "NESTED-"
         self.reserved_name = self.nested_prefix+"00000000-0000-0000-0000-000000000000"
         self.full_suffix = "-FULL"
@@ -255,7 +252,6 @@ class NestedRemoteRoot(RemoteRoot):
         try:
             reserved_subfolder = parent_folder.mkdir(self.reserved_name)
         except NumberOfChildrenExceededError:
-            self.annex.info("WARNING: "+self.full_message)
             return
 
 
@@ -298,7 +294,7 @@ class NestedRemoteRoot(RemoteRoot):
                                         " for instructions to do it manually."
                                     )
             else:
-                raise RemoteError(  "Remote folder is full. Cannot upload key."
+                raise RemoteError(  "Remote folder is full (max. 500.000 files exceeded). Cannot upload key."
                                     " Invoke `enableremote` with `auto_fix_full=yes`"
                                     " or consult https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder"
                                     " for instructions to do it manually."

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -189,14 +189,18 @@ class NestedRemoteRoot(RemoteRoot):
             except NumberOfChildrenExceededError:
                 self.annex.info("WARNING: " + self.full_message)
 
-    def _get_subfolders(self):
-        f = []
-        while(True):
-            try:
-                f.append(self.folder.child(format(len(f), self.folder_format)))
-            except FileNotFoundError:
-                break
-        return f
+    def _subfolders(self, level=0, start=0):
+        existing_folders = self.folder.children(folders=True, files=False, orderBy="name", skip=start)
+        for i in itertools.count(start):
+            folder = next(existing_folders, None)
+            if folder:
+                folder.rename(format(i, self.folder_format))
+                yield folder
+            else:
+                try:
+                    yield self.folder.mkdir(format(i, self.folder_format))
+                except NumberOfChildrenExceededError:
+                    return
 
     def _lookup_remote_file(self, key):
         remote_file = self._find_elsewhere(key)

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -23,6 +23,8 @@ from drivelib import ResumableMediaUploadProgress, MediaDownloadProgress
 from drivelib import AmbiguousPathError
 from drivelib import Credentials
 
+from annexremote import Master as Annex
+
 from googleapiclient.errors import HttpError
 
 import logging
@@ -34,7 +36,8 @@ class HasSubdirError(Exception):
     pass
 
 class RemoteRootBase(abc.ABC):
-    def __init__(self, rootfolder: DriveFolder, uuid: str=None, local_appdir: Union(str, PathLike)=None):
+    def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
+        self.annex = annex
         self.folder = rootfolder
         self.uuid = uuid
         if local_appdir is not None:
@@ -66,8 +69,8 @@ class RemoteRootBase(abc.ABC):
         return self.folder.drive.creds
 
 class RemoteRoot(RemoteRootBase):
-    def __init__(self, rootfolder, uuid: str=None, local_appdir: Union(str, PathLike)=None):
-        super().__init__(rootfolder, uuid=uuid, local_appdir=local_appdir)
+    def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
+        super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)
 
     def get_key(self, key: str) -> Key:
         try:
@@ -112,17 +115,20 @@ class RemoteRoot(RemoteRootBase):
         for p in f.parents:
             path = "/".join((p.name,path))
             if p == self.folder:
+                self.annex.debug("Found key in {}".format(path))
                 return True
         return False
 
     def _trash_empty_parents(self, parent: DriveFolder):
         for p in itertools.chain([parent], parent.parents):
             if p.isempty():
+                self.annex.debug("Trashing empty folder {}".format(p.name))
                 p.trash()
             else:
                 break
 
     def _find_elsewhere(self, key: str) -> DriveFile:
+        self.annex.debug("Not found. Trying differnt locations.")
         query = "name='{}'".format(key)
         query += " and mimeType != 'application/vnd.google-apps.folder'"
         query += " and trashed = false"
@@ -134,8 +140,8 @@ class RemoteRoot(RemoteRootBase):
         raise FileNotFoundError
 
 class NodirRemoteRoot(RemoteRoot):
-    def __init__(self, rootfolder, uuid: str=None, local_appdir: Union(str, PathLike)=None):
-        super().__init__(rootfolder, uuid=uuid, local_appdir=local_appdir)
+    def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
+        super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)
         if next(self.folder.children(files=False), None):
             self.has_subdirs = True
         else:

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -112,6 +112,10 @@ class RemoteRoot(RemoteRootBase):
     def _new_remote_file(self, key: str):
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def handle_full_folder(self):
+        raise NotImplementedError
+
     def _is_descendant_of_root(self, f: DriveFile) -> bool:
         path = ""
         for p in f.parents:
@@ -165,6 +169,12 @@ class NodirRemoteRoot(RemoteRoot):
     def _new_remote_file(self, key):
         return self.folder.new_file(key)
 
+    def handle_full_folder(self):
+        error_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
+                            " Please switch to a different layout and drop at least one key "\
+                            " from the remote so it can automatically migrate.".format(self.folder.name)
+        raise RemoteError(error_message)
+
 class NestedRemoteRoot(RemoteRoot):
     def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
         super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)
@@ -215,6 +225,10 @@ class NestedRemoteRoot(RemoteRoot):
                 raise
         self.subfolders.append(new_folder)
 
+    def handle_full_folder(self):
+        raise NotImplementedError
+        #TODO
+        
 
 
 class Key():

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -202,8 +202,7 @@ class NestedRemoteRoot(RemoteRoot):
     def next_subfolder(self):
         if not hasattr(self, "_subfolders"):
             self._subfolders = self._sub_generator(self.folder)
-        f = next(self._subfolders)
-        print("hallo")
+        f = next(self._subfolders, None)
         return f
 
     def _sub_generator(self, parent_folder=None):

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -150,6 +150,45 @@ class RemoteRoot(RemoteRootBase):
                 return f
         raise FileNotFoundError
 
+    def _auto_fix_full(self):
+        self.annex.info("Remote folder full. Fixing...")
+        original_prefix = self.folder.name
+        new_root = None
+        try:
+            new_root = self.folder.parent.mkdir(self.folder.name+".new")
+            self.annex.debug("Created folder {}({})".format(new_root.name, new_root.id))
+        except:
+            raise RemoteError("Couldn't create new folder in {parent_name} ({parent_id})"
+                        " Nothing was changed."
+                        " Please consult https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder"
+                        " for instructions to fix it manually.".format(
+                                parent_name = self.folder.parent.name,
+                                parent_id = self.folder.parent.id
+                            )
+                        )
+        try:
+            self.folder.move(new_root, new_name=original_prefix+".old")
+        except:
+            # new_root.rmdir()
+            raise RemoteError("Couldn't move the root folder."
+                        " Nothing was changed."
+                        " Please consult https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder"
+                        " for instructions to fix it manually."
+                        )
+        try:
+            new_root.rename(original_prefix)
+        except:
+            raise RemoteError("Couldn't rename new folder to prefix."
+                        " Please manually rename {new_name} ({new_id}) to {prefix}.".format(
+                                                        new_name = new_root.name,
+                                                        new_id = new_root.id,
+                                                        prefix = original_prefix
+                                                    )
+                        )
+        self.annex.info("Success")
+
+        self.folder = new_root
+
 class NodirRemoteRoot(RemoteRoot):
     def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
         super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)
@@ -242,43 +281,7 @@ class NestedRemoteRoot(RemoteRoot):
         return self._find_elsewhere(key)
 
     def _auto_fix_full(self):
-        self.annex.info("Remote folder full. Fixing...")
-        original_prefix = self.folder.name
-        new_root = None
-        try:
-            new_root = self.folder.parent.mkdir(self.folder.name+".new")
-            self.annex.debug("Created folder {}({})".format(new_root.name, new_root.id))
-        except:
-            raise RemoteError("Couldn't create new folder in {parent_name} ({parent_id})"
-                        " Nothing was changed."
-                        " Please consult https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder"
-                        " for instructions to fix it manually.".format(
-                                parent_name = self.folder.parent.name,
-                                parent_id = self.folder.parent.id
-                            )
-                        )
-        try:
-            self.folder.move(new_root, new_name=original_prefix+".old")
-        except:
-            # new_root.rmdir()
-            raise RemoteError("Couldn't move the root folder."
-                        " Nothing was changed."
-                        " Please consult https://github.com/Lykos153/git-annex-remote-googledrive#fix-full-folder"
-                        " for instructions to fix it manually."
-                        )
-        try:
-            new_root.rename(original_prefix)
-        except:
-            raise RemoteError("Couldn't rename new folder to prefix."
-                        " Please manually rename {new_name} ({new_id}) to {prefix}.".format(
-                                                        new_name = new_root.name,
-                                                        new_id = new_root.id,
-                                                        prefix = original_prefix
-                                                    )
-                        )
-        self.annex.info("Success")
-
-        self.folder = new_root
+        super()._auto_fix_full()
         del self._subfolders
         self.current_folder = self.next_subfolder()
 

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -69,13 +69,6 @@ class RemoteRoot(RemoteRootBase):
         super().__init__(rootfolder, uuid=uuid, local_appdir=local_appdir)
 
     def get_key(self, key: str) -> Key:
-        k = self.key(key)
-        if k.file.id:
-            return k
-        else:
-            raise FileNotFoundError
-
-    def key(self, key: str) -> Key:
         try:
             remote_file = self._lookup_remote_file(key)
         except AmbiguousPathError as e:
@@ -87,12 +80,16 @@ class RemoteRoot(RemoteRootBase):
                     dup.remove()
                 else:
                     raise
-        except FileNotFoundError:
-            # Uploading an existing key is not an error
-            remote_file = self._new_remote_file(key)
-            
+
         if remote_file.isfolder():
             raise NotAFileError(key)
+        return Key(self, key, remote_file)
+
+    def new_key(self, key: str) -> Key:
+        try:
+            remote_file = self._new_remote_file(key)
+        except FileExistsError:
+            return self.get_key(key)
         return Key(self, key, remote_file)
 
     def delete_key(self, key: str):

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -14,6 +14,7 @@ from pathlib import PurePath
 from os import PathLike
 import abc
 import itertools
+import uuid
 
 from drivelib import GoogleDrive
 from drivelib import DriveFile
@@ -185,62 +186,52 @@ class NestedRemoteRoot(RemoteRoot):
         self.full_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
                             " Please drop at least one key from the remote, so it can automatically" \
                             " migrate to the 'nested' layout.".format(self.folder.name)
-        self.folder_format = "05x" # subfolders() depends on this not being changed. Maybe use parse module?
-        self.reserved_name = "sub"
-
-        if self.current_folder is None:
-            self.current_folder = self.next_subfolder()
-
+        self.reserved_name = "00000000-0000-0000-0000-000000000000"
+        self.full_suffix = "-FULL"
 
     @property
     def current_folder(self):
         if not hasattr(self, "_current_folder"):
-            try:
-                self._current_folder_link = self.folder.child("cur")
-            except FileNotFoundError:
-                self._current_folder_link = None
-        if self._current_folder_link:
-            return self._current_folder_link.target
-        else:
-            return None
+            self._current_folder = self.next_subfolder()
+        return self._current_folder
 
     @current_folder.setter
     def current_folder(self, new_target: DriveFolder):
-        if self.current_folder:
-            self._current_folder_link.remove()
-        self._current_folder_link = new_target.create_shortcut("cur", parent=self.folder)
-            
+        self._current_folder = new_target
+
     def next_subfolder(self):
         if not hasattr(self, "_subfolders"):
-            if self.current_folder:
-                parent_level = self.current_folder.parent
-                start_count = int(self.current_folder.name, 16)+1 # assumes folder format is hex. Maybe use parse module instead
-            else:
-                parent_level = self.folder
-                start_count = 0
-            self._subfolders = self._sub_generator(parent_folder=parent_level, start=start_count)
-        return next(self._subfolders)
+            self._subfolders = self._sub_generator(self.folder)
+        f = next(self._subfolders)
+        print("hallo")
+        return f
 
-    def _sub_generator(self, parent_folder=None, start=0):
+    def _sub_generator(self, parent_folder=None):
         parent_folder = parent_folder or self.folder
         try:
-            reserved_subfolder = parent_folder.create_path(self.reserved_name)
+            reserved_subfolder = parent_folder.mkdir(self.reserved_name)
         except NumberOfChildrenExceededError:
             self.annex.info("WARNING: "+self.full_message)
             return
 
-        existing_folders = parent_folder.children(folders=True, files=False, orderBy="name", skip=start)
-        for i in itertools.count(start):
-            folder = next(existing_folders, None)
-            if folder:
-                if folder.name != self.reserved_name:
-                    folder.rename(format(i, self.folder_format))
-                    yield folder
+
+        query =     "'{}' in parents".format(self.folder.id)
+        query +=    " and not name contains '{}'".format(self.full_suffix)
+        query +=    " and name != '{}'".format(self.reserved_name)
+        query +=    " and mimeType = 'application/vnd.google-apps.folder'"
+        query +=    " and trashed = false"
+        yield from self.folder.drive.items_by_query(query)
+
+
+        while True:
+            try:
+                new_folder = parent_folder.mkdir(str(uuid.uuid4()))
+            except NumberOfChildrenExceededError:
+                break
             else:
-                try:
-                    yield self.folder.mkdir(format(i, self.folder_format))
-                except NumberOfChildrenExceededError:
-                    yield from self._subfolders(parent_folder=reserved_subfolder)
+                yield new_folder
+
+        yield from self._sub_generator(parent_folder=reserved_subfolder)
 
     def _lookup_remote_file(self, key):
         return self._find_elsewhere(key)
@@ -251,6 +242,7 @@ class NestedRemoteRoot(RemoteRoot):
         return self.current_folder.new_file(key)
 
     def handle_full_folder(self):
+        self.current_folder.rename(self.current_folder.name+self.full_suffix)
         self.current_folder = self.next_subfolder()
 
 class Key():

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -239,30 +239,3 @@ class ExportKey(Key):
     def __init__(self, root: ExportRemoteRoot, key: str, path: Union(str, PathLike), remote_file: DriveFile):
         super().__init__(root, key, remote_file)
         self.path = PurePath(path)
-
-class MigrationRoot(RemoteRootBase):
-    def __init__(self, rootfolder):
-        super().__init__(rootfolder)
-        self.migration_count = {'moved':0, 'deleted':0}
-
-    def migrate(self):
-        self._migration_traverse(self.folder, "")
-        return self.migration_count
-    
-    #@retry(wait=wait_fixed(2), retry=retry_conditions['retry'])   
-    def _migration_traverse(self, current_folder, current_path) -> Dict[str, int]:
-        #TODO: Use batch requests
-        if current_folder == self.folder:
-            for subfolder in current_folder.children(files=False):
-                self._migration_traverse(subfolder, current_path+"/"+subfolder.name)
-        else:
-            for file_ in current_folder.children():
-                if isinstance(file_, DriveFolder):
-                    self._migration_traverse(file_, current_path+"/"+file_.name)
-                else:
-                    print ( "Moving {}/{}".format(current_path,file_.name) )
-                    file_.move(self.folder)
-                    self.migration_count['moved'] += 1
-            print ("Deleting folder {}".format(current_path))
-            current_folder.remove()
-            self.migration_count['deleted'] += 1

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -68,7 +68,6 @@ class RemoteRoot(RemoteRootBase):
         super().__init__(rootfolder, uuid=uuid, local_appdir=local_appdir)
         if next(self.folder.children(files=False), None):
             raise HasSubdirError()
-        self._delete_test_keys()
 
     def get_key(self, key: str) -> Key:
         k = self.key(key)
@@ -103,11 +102,6 @@ class RemoteRoot(RemoteRootBase):
         except FileNotFoundError:
             pass
 
-    def _delete_test_keys(self):
-        query = "'{root_id}' in parents and \
-                    name contains 'this-is-a-test-key'".format(
-                    root_id=self.folder.id
-                    )
 
         for test_key in self.folder.drive.items_by_query(query):
             test_key.remove()

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -191,7 +191,8 @@ class NestedRemoteRoot(RemoteRoot):
         self.full_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
                             " Please drop at least one key from the remote, so it can automatically" \
                             " migrate to the 'nested' layout.".format(self.folder.name)
-        self.reserved_name = "00000000-0000-0000-0000-000000000000"
+        self.nested_prefix = "NESTED-"
+        self.reserved_name = self.nested_prefix+"00000000-0000-0000-0000-000000000000"
         self.full_suffix = "-FULL"
 
     @property
@@ -229,7 +230,7 @@ class NestedRemoteRoot(RemoteRoot):
 
         while True:
             try:
-                new_folder = parent_folder.mkdir(str(uuid.uuid4()))
+                new_folder = parent_folder.mkdir(self.nested_prefix+str(uuid.uuid4()))
             except NumberOfChildrenExceededError:
                 break
             else:

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -80,12 +80,13 @@ class RemoteRoot(RemoteRootBase):
     def key(self, key: str) -> Key:
         try:
             remote_file = self.folder.child(key)
-        except AmbiguousPathError:
-            files = self.folder.children(name=key)
-            remote_file = next(files)
-            for current_file in files:
-                if current_file.md5sum == remote_file.md5sum:
-                    current_file.remove()
+        except AmbiguousPathError as e:
+            if not hasattr(e, "duplicates"):
+                raise
+            remote_file = next(e.duplicates)
+            for dup in e.duplicates:
+                if dup.md5sum == remote_file.md5sum:
+                    dup.remove()
                 else:
                     raise
         except FileNotFoundError:

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -15,6 +15,7 @@ from os import PathLike
 import abc
 import itertools
 import uuid
+from typing import Union
 
 from drivelib import GoogleDrive
 from drivelib import DriveFile

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -156,8 +156,9 @@ class RemoteRoot(RemoteRootBase):
         original_prefix = self.folder.name
         new_root = None
         try:
+            self.annex.info("Creating new root folder")
             new_root = self.folder.parent.mkdir(self.folder.name+".new")
-            self.annex.debug("Created folder {}({})".format(new_root.name, new_root.id))
+            self.annex.info("Created as {}({})".format(new_root.name, new_root.id))
         except:
             raise RemoteError("Couldn't create new folder in {parent_name} ({parent_id})"
                         " Nothing was changed."
@@ -168,7 +169,9 @@ class RemoteRoot(RemoteRootBase):
                             )
                         )
         try:
-            self.folder.move(new_root, new_name=original_prefix+".old")
+            new_name=original_prefix+".old"
+            self.annex.info("Moving old root to new one, renaming to {}".format(new_name))
+            self.folder.move(new_root, new_name=new_name)
         except:
             # new_root.rmdir()
             raise RemoteError("Couldn't move the root folder."
@@ -177,6 +180,7 @@ class RemoteRoot(RemoteRootBase):
                         " for instructions to fix it manually."
                         )
         try:
+            self.annex.info("Renaming new root to original prefix: {}".format(original_prefix))
             new_root.rename(original_prefix)
         except:
             raise RemoteError("Couldn't rename new folder to prefix."

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -22,8 +22,10 @@ from drivelib import NotAuthenticatedError, CheckSumError
 from drivelib import ResumableMediaUploadProgress, MediaDownloadProgress
 from drivelib import AmbiguousPathError
 from drivelib import Credentials
+from drivelib.errors import NumberOfChildrenExceededError
 
 from annexremote import Master as Annex
+from annexremote import RemoteError
 
 from googleapiclient.errors import HttpError
 
@@ -167,15 +169,21 @@ class NestedRemoteRoot(RemoteRoot):
     def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
         super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)
         self.subfolders = self._get_subfolders()
+        self.full_message = "Remote root folder {} is full (max. 500.000 files exceeded)." \
+                            " Please drop at least one key from the remote, so it can automatically" \
+                            " migrate to the 'nested' layout.".format(self.folder.name)
+        self.folder_format = "05x"
         if len(self.subfolders) == 0:
-            #TODO Check for full folder
-            self.subfolders.append(self.folder.mkdir(format(0, "05x")))
+            try:
+                self._new_subfolder()
+            except NumberOfChildrenExceededError:
+                self.annex.info("WARNING: " + self.full_message)
 
     def _get_subfolders(self):
         f = []
         while(True):
             try:
-                f.append(self.folder.child(format(len(f), "05x")))
+                f.append(self.folder.child(format(len(f), self.folder_format)))
             except FileNotFoundError:
                 break
         return f
@@ -189,8 +197,23 @@ class NestedRemoteRoot(RemoteRoot):
 
 
     def _new_remote_file(self, key):
-        #TODO: Check for full folder
-        return self.subfolders[-1].new_file(key)
+        if len(self.subfolders) == 0:
+                raise RemoteError(self.full_message)
+        try:
+            return self.subfolders[-1].new_file(key)
+        except NumberOfChildrenExceededError:
+            #TODO: Will never happen, because error is only thrown when uploading. Maybe replace "new" with dedicated "upload" function
+            pass
+
+    def _new_subfolder(self):
+        try:
+            new_folder = self.folder.mkdir(format(len(self.subfolders), self.folder_format))
+        except NumberOfChildrenExceededError:
+            if len(self.subfolders > 0):
+                new_folder = self.subfolders[-1].mkdir(format(len(self.subfolders), self.folder_format))
+            else:
+                raise
+        self.subfolders.append(new_folder)
 
 
 

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -163,6 +163,36 @@ class NodirRemoteRoot(RemoteRoot):
     def _new_remote_file(self, key):
         return self.folder.new_file(key)
 
+class NestedRemoteRoot(RemoteRoot):
+    def __init__(self, rootfolder: DriveFolder, annex: Annex, uuid: str=None, local_appdir: Union(str, PathLike)=None):
+        super().__init__(rootfolder, annex, uuid=uuid, local_appdir=local_appdir)
+        self.subfolders = self._get_subfolders()
+        if len(self.subfolders) == 0:
+            #TODO Check for full folder
+            self.subfolders.append(self.folder.mkdir(format(0, "05x")))
+
+    def _get_subfolders(self):
+        f = []
+        while(True):
+            try:
+                f.append(self.folder.child(format(len(f), "05x")))
+            except FileNotFoundError:
+                break
+        return f
+
+    def _lookup_remote_file(self, key):
+        remote_file = self._find_elsewhere(key)
+        if remote_file.parent not in self.subfolders:
+            #TODO support nested folders
+            remote_file.move(self.subfolders[-1])
+        return remote_file
+
+
+    def _new_remote_file(self, key):
+        #TODO: Check for full folder
+        return self.subfolders[-1].new_file(key)
+
+
 
 class Key():
     def __init__(self, root: RemoteRootBase, key: str, remote_file: DriveFile):

--- a/git_annex_remote_googledrive/keys.py
+++ b/git_annex_remote_googledrive/keys.py
@@ -152,6 +152,10 @@ class NodirRemoteRoot(RemoteRoot):
             self.has_subdirs = True
         else:
             self.has_subdirs = False
+        self.annex.info("WARNING: Google has introduced a maximum file count per folder."
+                        " Thus, `nodir` is no longer a good choice. Please consider migrating"
+                        " to a different layout.")
+        # automatically migrate to nested if nodir wasn't explicitely asked for
 
     def _lookup_remote_file(self, key: str) -> DriveFile:
         try: 

--- a/git_annex_remote_googledrive/run.py
+++ b/git_annex_remote_googledrive/run.py
@@ -113,7 +113,7 @@ def main():
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest='subcommand')
 
-        parser_migrate = subparsers.add_parser('version',
+        parser_version = subparsers.add_parser('version',
                                     help='Show version of {} and relevant libraries'.format(__name__))
         parser_migrate = subparsers.add_parser('migrate',
                                     help='Migrate a folder to nodir structure')

--- a/git_annex_remote_googledrive/run.py
+++ b/git_annex_remote_googledrive/run.py
@@ -115,10 +115,6 @@ def main():
 
         parser_version = subparsers.add_parser('version',
                                     help='Show version of {} and relevant libraries'.format(__name__))
-        parser_migrate = subparsers.add_parser('migrate',
-                                    help='Migrate a folder to nodir structure')
-        parser_migrate.add_argument('prefix', type=str,
-                                        help='Path to folder which should be migrated')
 
         parser_setup = subparsers.add_parser('setup',
                                     help='Authenticate with Google to prepare for initremote/enableremote')
@@ -146,30 +142,6 @@ def main():
             print(MODULENAME, __version__)
             print("Using AnnexRemote", annexremote_version)
             print("Using drivelib", drivelib_version)
-            return
-        elif args.subcommand == 'migrate':
-            with open(os.devnull, 'w') as devnull:
-                master = Master(devnull)
-                remote = GoogleRemote(master)
-                try:
-                    migration_count = remote.migrate(args.prefix)
-                except (KeyboardInterrupt, SystemExit):
-                    print ("\n{}Exiting.".format(bcolors.WARNING))
-                    print ("The remote is in an undefined state now. Re-run this script before using git-annex on it.")
-                except Exception as e:
-                    print ("\n{}Error: {}".format(bcolors.FAIL, e))
-                    print ("The remote is in an undefined state now. Re-run this script before using git-annex on it.")
-                else:
-                    print ("\n{}Finished.".format(bcolors.OKGREEN))
-                    print ("The remote has benn successfully migrated and can now be used with git-annex-remote-googledrive. Consider checking consistency with 'git annex fsck --from=<remotename> --fast'")
-                    print ( "Processed {} subfolders".format(
-                                    migration_count['deleted']))
-                    print ( "Moved {} files{}".format(
-                                migration_count['moved'],
-                                bcolors.ENDC
-                            )
-                    )
-
             return
 
     output = sys.stdout


### PR DESCRIPTION
This application was designed under the premise that Google Drive doesn't have a concept of folders and thus can efficiently handle an infinite amount of files per folder. However, recently they put a restriction on the number of files per folder (500k) (see #52).
To address this issue, currently the following steps are planned:
1. Add support for different layouts 
2. Implement a simple nested layout and automatic migration to this layout, make it the default layout and deprecate `nodir`
3. Implement the layouts supported by [git-annex-remote-rclone](https://github.com/DanielDent/git-annex-remote-rclone#usage) and [git-annex-remote-gdrive](https://github.com/Lykos153/git-annex-remote-gdrive#using-an-existing-remote-note-on-repository-layout) (except `frankencase`).
4. Implement migration between all the layouts